### PR TITLE
Printing Continues

### DIFF
--- a/src/com/is2300/rcp/printer/Printer.java
+++ b/src/com/is2300/rcp/printer/Printer.java
@@ -110,9 +110,13 @@ public class Printer {
             ex.printStackTrace(System.err);
             return success;
         } catch (PrintException ex) {
-            System.err.println(ex.getMessage());
-            ex.printStackTrace(System.err);
-            return success;
+            if ( ex.getMessage().contains("already printing") ) {
+                success = true;
+            } else {
+                System.err.println(ex.getMessage());
+                ex.printStackTrace(System.err);
+                return success;
+            }
         }
         
         return success;


### PR DESCRIPTION
In this iteration, I've still not corrected the printout format, but I've gotten to where all files in the source tree are successfully printing.

There is something with the `PrintException` that it gets thrown on every print job with the message "already printing". Therefore, I added an `if()...else` into the `catch ( PrintException ex)` block to ignore those exceptions by testing if the message contains the text "already printing". Now, the print counter in the `PrintSetup` class is counting each document that prints, so that the job report at the end is correct. At this point, with only having three (3) `*.java` files in the source tree, the utility is printing the three files in 0 seconds. So the speed is there. Once I start working on the format of the printouts, we'll see what that does to the execution speed...